### PR TITLE
dmd fix missing lib files

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,11 +1,19 @@
 #!/bin/bash
 
-mkdir -p $PREFIX/bin
+mkdir -p $PREFIX/lib/dmd/src/phobos/
+cd $SRC_DIR/src/phobos
+cp -r * $PREFIX/lib/dmd/src/phobos/
 
+mkdir -p $PREFIX/lib/dmd/src/druntime/import/
+cd $SRC_DIR/src/druntime/import
+cp -r * $PREFIX/lib/dmd/src/druntime/import/
+
+mkdir -p $PREFIX/lib/dmd/linux/lib64/
+cd $SRC_DIR/linux/lib64/
+cp -r * $PREFIX/lib/dmd/linux/lib64/
+
+mkdir -p $PREFIX/bin
 cd $SRC_DIR/linux/bin64/
 
 chmod a+x ddemangle dman dmd dumpobj dustmite obj2asm rdmd
-
 cp ddemangle dman dmd dumpobj dustmite obj2asm rdmd $PREFIX/bin
-
-export DFLAGS="-I$SRC_DIR/src/phobos -I$SRC_DIR/src/druntime/import -L-L$SRC_DIR/linux/lib64 -L--export-dynamic"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win or osx or not x86_64]  
   
 test:


### PR DESCRIPTION
The dmd installation is working fine, but when using dmd to compile I got the following error:

```
Error: cannot find source code for runtime library file 'object.d'
       dmd might not be correctly installed. Run 'dmd -man' for installation instructions.
```

There are some library files missing that I added to the build.sh.

To dmd run properly it is necessary to specify the env. variable DFLAGS. I could do it before running my script, but it would be better if it is already set after installation. Is that possible?

`export DFLAGS="-I$PREFIX/lib/dmd/src/phobos -I$PREFIX/lib/dmd/src/druntime/import -L-L$PREFIX/lib/dmd/linux/lib64 -L--export-dynamic"`