### PR TITLE
Fix skip selector

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [win or osx or not x86_64]  
+  skip: True  # [not linux64]
   
 test:
   commands:    


### PR DESCRIPTION
Fixes https://github.com/conda-forge/dmd-feedstock/issues/2

Changes selector to not use `x86_64`. Should fix the team/feestocks update script.

cc @conda-forge/core